### PR TITLE
Fixed a bug when the source assembly doesn't include a ".reloc" section

### DIFF
--- a/ILRepack/Steps/Win32Resources/PE/ImageWriter.cs
+++ b/ILRepack/Steps/Win32Resources/PE/ImageWriter.cs
@@ -136,7 +136,10 @@ namespace ILRepacking.Steps.Win32Resources.PE
             WriteSectionHeaders();
             CopySection(_origText, _text);
             WriteSection(_rsrc, _win32Resources);
-            CopySection(_origReloc, _reloc);
+            if (_reloc != null)
+            {
+                CopySection(_origReloc, _reloc);
+            }
         }
 
         private void CopyBytes(int bytes)


### PR DESCRIPTION
When the assembly doesn't include a ".reloc" section, the ImageWriter would throw a null reference exception. This fix, skips copying the reloc section if it doesn't exist.